### PR TITLE
Fix replaced prerelease string

### DIFF
--- a/Source/ReplacementValues.ts
+++ b/Source/ReplacementValues.ts
@@ -28,7 +28,7 @@ export class ReplacementValues implements IReplacementValues {
             case 'patch':
                 return this._version.patch.toString();
             case 'prerelease':
-                return this._version.prerelease.toString();
+                return this._version.prerelease.join('.');
             case 'full':
                 return this._version.format();
         }


### PR DESCRIPTION
## Summary

The `semver` library exposes the `prerelease` of the parsed versions as an array of elements. `.toString()` joined these with a comma making the replaced prerelease value strange. This PR fixes that by using `.join('.')` instead.

### Fixed

- The replaced `prerelease` strings now contains `.` instead of `,`.